### PR TITLE
Changed vos_utils to ovos_utils

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-vos_utils>=0.0.8a2
+ovos_utils>=0.0.8a2
 youtube-dl
 pafy


### PR DESCRIPTION
I've tried to install that skill on KDE Neon, but I got that error:
ERROR: No matching distribution found for vos_utils>=0.0.8a2